### PR TITLE
todo一覧のレイアウトと画面全体のレイアウトの調整

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
                     <Header>Header</Header>
                 </div>
                 <Content>
-                    <div style={{ height: `calc(100vh - ${headerHeight}px - ${footerHeight}px)` }}>
+                    <div className="mt-2" style={{ height: `calc(100vh - ${headerHeight}px - ${footerHeight}px)` }}>
                         <TodoList />
                     </div>
                 </Content>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
                     <Header>Header</Header>
                 </div>
                 <Content>
-                    <div className="mt-2" style={{ height: `calc(100vh - ${headerHeight}px - ${footerHeight}px)` }}>
+                    <div style={{ height: `calc(100vh - ${headerHeight}px - ${footerHeight}px)` }}>
                         <TodoList />
                     </div>
                 </Content>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import { Card, CardContent, CardTitle } from "@/components/elements/Card";
 import Modal from "@/components/elements/Modal";
 import Content from "@/components/layouts/Content";
 import Footer from "@/components/layouts/Footer";
@@ -10,7 +11,7 @@ import Page from "@/components/layouts/Page";
 import EditTodoModal from "@/features/routes/todo/EditTodoModal";
 import NewTodoModal from "@/features/routes/todo/NewTodoModal";
 import TodoDetailModal from "@/features/routes/todo/TodoDetailModal";
-import Todos from "@/features/routes/todo/Todos";
+import TodoList from "@/features/routes/todo/TodoList";
 import { useSetModal } from "@/hooks/useModals";
 import useResetTodosAtom from "@/hooks/useTodo";
 
@@ -19,24 +20,47 @@ export default function Home() {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const reset = useResetTodosAtom();
 
+    // Todo一覧の高さの調整（全体の画面の縦幅が100vhになるようにする。）
+    const headerRef = useRef<HTMLDivElement>(null);
+    const footerRef = useRef<HTMLDivElement>(null);
+    const [headerHeight, setHeaderHeight] = useState(0);
+    const [footerHeight, setFooterHeight] = useState(0);
+    useEffect(() => {
+        if (headerRef.current === null || footerRef.current === null) return;
+        setHeaderHeight(headerRef.current.offsetHeight);
+        setFooterHeight(footerRef.current.offsetHeight);
+    }, []);
+
     return (
         <>
             <Page>
-                <Header>Header</Header>
+                <div ref={headerRef}>
+                    <Header>Header</Header>
+                </div>
                 <Content>
-                    <Todos />
+                    <div style={{ height: `calc(100vh - ${headerHeight}px - ${footerHeight}px)` }}>
+                        <TodoList />
+                    </div>
                 </Content>
-                <Footer>
-                    <button className="m-1 w-32 rounded-2xl bg-sky-600 px-2 py-1 shadow-xl" onClick={() => setIsModalOpen(true)}>
-                        <text className="text-xl text-white">Open</text>
-                    </button>
-                    <button className="m-1 w-32 rounded-2xl bg-sky-600 px-2 py-1 shadow-xl" onClick={() => setModal("newTodo")}>
-                        <text className="text-xl text-white">Create</text>
-                    </button>
-                    <button className="m-1 w-32 rounded-2xl bg-sky-600 px-2 py-1 shadow-xl" onClick={() => reset()}>
-                        <text className="text-xl text-white">Reset</text>
-                    </button>
-                </Footer>
+                <div ref={footerRef}>
+                    <Footer>
+                        <button
+                            className="m-1 w-32 rounded-2xl bg-sky-600 px-2 py-1 shadow-xl"
+                            onClick={() => setIsModalOpen(true)}
+                        >
+                            <text className="text-xl text-white">Open</text>
+                        </button>
+                        <button
+                            className="m-1 w-32 rounded-2xl bg-sky-600 px-2 py-1 shadow-xl"
+                            onClick={() => setModal("newTodo")}
+                        >
+                            <text className="text-xl text-white">Create</text>
+                        </button>
+                        <button className="m-1 w-32 rounded-2xl bg-sky-600 px-2 py-1 shadow-xl" onClick={() => reset()}>
+                            <text className="text-xl text-white">Reset</text>
+                        </button>
+                    </Footer>
+                </div>
             </Page>
 
             <NewTodoModal />
@@ -51,9 +75,24 @@ export default function Home() {
                     <Header>
                         <text>test</text>
                     </Header>
-                    <button className="m-1 w-32 rounded-2xl bg-sky-600 px-2 py-1 shadow-xl" onClick={() => setIsModalOpen(false)}>
-                        <text className="text-xl text-white">Close</text>
-                    </button>
+                    <Content>
+                        <Card>
+                            <CardTitle>Title</CardTitle>
+                            <CardContent>Content</CardContent>
+                        </Card>
+                        <Card>
+                            <CardTitle>Title</CardTitle>
+                            <CardContent>Content</CardContent>
+                        </Card>
+                    </Content>
+                    <Footer>
+                        <button
+                            className="m-1 w-32 rounded-2xl bg-sky-600 px-2 py-1 shadow-xl"
+                            onClick={() => setIsModalOpen(false)}
+                        >
+                            <text className="text-xl text-white">Close</text>
+                        </button>
+                    </Footer>
                 </Page>
             </Modal>
         </>

--- a/src/components/elements/Card.tsx
+++ b/src/components/elements/Card.tsx
@@ -1,9 +1,17 @@
 export function Card({ children }: Readonly<{ children: React.ReactNode }>) {
-    return <div className="flex flex-col">{children}</div>;
+    return (
+        <div className="relative z-0 m-1 flex flex-col rounded-2xl border-2 bg-white p-2 shadow-lg transition-all duration-300 hover:z-20 hover:-translate-y-3 hover:shadow-2xl">
+            {children}
+        </div>
+    );
 }
 
 export function CardTitle({ children }: Readonly<{ children: React.ReactNode }>) {
-    return <div className="flex flex-col">{children}</div>;
+    return (
+        <div className="flex flex-col">
+            <text className="underline decoration-solid underline-offset-4">{children}</text>
+        </div>
+    );
 }
 
 export function CardContent({ children }: Readonly<{ children: React.ReactNode }>) {

--- a/src/components/elements/Modal.tsx
+++ b/src/components/elements/Modal.tsx
@@ -24,7 +24,7 @@ export default function Modal({ children, isOpen }: Props) {
             id="modal"
             className={
                 isOpen
-                    ? "fixed inset-0 z-20 flex h-screen w-screen items-center justify-center overflow-hidden bg-black/90"
+                    ? "fixed inset-0 z-30 flex h-screen w-screen items-center justify-center overflow-hidden bg-black/90"
                     : "hidden"
             }
         >

--- a/src/features/routes/todo/TodoList.tsx
+++ b/src/features/routes/todo/TodoList.tsx
@@ -20,9 +20,9 @@ export default function TodoList() {
     };
 
     return (
-        <div className="relative grid size-full grid-flow-row grid-cols-4 overflow-scroll overflow-x-hidden">
+        <div className="relative grid size-full grid-flow-row grid-cols-4 content-start overflow-scroll overflow-x-hidden pt-3">
             {todos?.map((todo) => (
-                <div className="grid h-96" key={todo.id} onClick={() => openDetailModal(todo)}>
+                <div className="grid h-48" key={todo.id} onClick={() => openDetailModal(todo)}>
                     <Card>
                         <CardTitle>{todo?.title}</CardTitle>
                         <CardContent>{todo?.content}</CardContent>

--- a/src/features/routes/todo/TodoList.tsx
+++ b/src/features/routes/todo/TodoList.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 
+import { Card, CardContent, CardTitle } from "@/components/elements/Card";
 import { useSetModal } from "@/hooks/useModals";
 import { Todo, useSetID, useTodos } from "@/hooks/useTodo";
 
-export default function Todos() {
+export default function TodoList() {
     const setModal = useSetModal();
     const [todos, setTodos] = useState<Todo[]>([]);
     const allTodos = useTodos();
@@ -19,11 +20,13 @@ export default function Todos() {
     };
 
     return (
-        <div className="relative grid h-full grid-flow-row grid-cols-4 overflow-scroll overflow-x-hidden">
+        <div className="relative grid size-full grid-flow-row grid-cols-4 overflow-scroll overflow-x-hidden">
             {todos?.map((todo) => (
-                <div key={todo.id} className="m-4 flex h-48 flex-col border" onClick={() => openDetailModal(todo)}>
-                    <text>{todo?.title}</text>
-                    <text>{todo?.content}</text>
+                <div className="grid h-96" key={todo.id} onClick={() => openDetailModal(todo)}>
+                    <Card>
+                        <CardTitle>{todo?.title}</CardTitle>
+                        <CardContent>{todo?.content}</CardContent>
+                    </Card>
                 </div>
             ))}
         </div>


### PR DESCRIPTION
## 概要

todo一覧のレイアウトと画面全体のレイアウトの調整をした。

## 作業内容

- todo一覧用のカードコンポーネントを作成
- todo一覧を表示するコンポーネントのスタイルの調整
- 上記コンポーネントが使用されているページにおいて、画面全体の縦幅がスクリーンになるように調整
- 上記3つの変更に伴う一部のコンポーネントのz-indexの調整

## 備考

todoのプロパティが増えた際にはその都度カードのデザインを変更する。
